### PR TITLE
alt.on should be alt.onServer

### DIFF
--- a/src/en/events/3_client_events.md
+++ b/src/en/events/3_client_events.md
@@ -347,7 +347,7 @@ alt.on('playerConnect', player => {
 **Client Side**
 
 ```js
-alt.on('setStreamedSyncedMetaChange', handleEvent);
+alt.onServer('streamSyncedMetaChange', handleEvent);
 
 function handleEvent(entity, key, value, oldValue) {
     // Filter out non-player types.


### PR DESCRIPTION
alt.on('setStreamSyncedMeta'...) is also wrong. Stream synced meta is set on server, so client has to listen to alt.onServer
also it's not setStreamSyncedMetaChange but stramSyncedMetaChange.
Now it's working. Sorry for first pullrequest. Change war right but i did not see that you had another issue in there